### PR TITLE
Mount an encrypted disk and backup every hour and eject right after.

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,13 +6,15 @@ A simple set of steps to create a simple script that is run every hour to automa
 ## Setup Instructions
 
 `timeMachineScript.sh`:
-1. Change line 3: use name of your backup harddisk (as it appears when its mounted)
+1. Change line 9: use name the UUID of your backup harddisk (Assuming the back up disk is mounted and named as "Backups of ..." -- `diskutil list | grep "Backups of" | awk '{print $NF}' | xargs  diskutil info | grep "Volume UUID:"` command can be used to display the UUID of the backup disk)
 2. Run `chmod +x timeMachineScript.sh`
 3. Move the file to a location of your choice (e.g. `~/bin/timeMachineScript.sh`)
+4. (tmutil: latestbackup requires Full Disk Access privileges) Give `timeMachineScript.sh` Full Disk Access rights by openning the System Settings > Privacy & Security > Full Disk Access window and dragging & dropping the `timeMachineScript.sh` file into it.
 
 `com.username.timeMachineScript.plist`:
 1. Change the name of this file: use your Mac username (e.g. `com.micah.timeMachineScript.plist`)
 2. Change line 6: use your Mac username (e.g. `com.micah.timeMachineScript`)
 3. Change line 9: use the path to the bash script chosen for `timeMachineScript.sh`
-4. Move the file to `/Users/username/Library/LaunchAgents` (where `username` is replaced with your Mac username)
-5. Run `launchctl load ~/Library/LaunchAgents/com.username.timeMachineScript.plist` (where `username` is replaced with your Mac username)
+4. Modify lines 16 and 18 to your liking or remove lines 15 through 18 altogether if you don't want logging
+5. Move the file to `/Users/username/Library/LaunchAgents` (where `username` is replaced with your Mac username)
+6. Run `launchctl load ~/Library/LaunchAgents/com.username.timeMachineScript.plist` (where `username` is replaced with your Mac username)

--- a/README.md
+++ b/README.md
@@ -10,6 +10,7 @@ A simple set of steps to create a simple script that is run every hour to automa
 2. Run `chmod +x timeMachineScript.sh`
 3. Move the file to a location of your choice (e.g. `~/bin/timeMachineScript.sh`)
 4. (tmutil: latestbackup requires Full Disk Access privileges) Give `timeMachineScript.sh` Full Disk Access rights by openning the System Settings > Privacy & Security > Full Disk Access window and dragging & dropping the `timeMachineScript.sh` file into it.
+5. This modification assumes that the disk is encyrpted and its password is registered in the master keychain. `security` binary will ask permission to access this login item (which can be find by searching the UUID in Keychain Access.app). Basically the script will query the password of the backup disk everytime it runs so that it can mount the disk.
 
 `com.username.timeMachineScript.plist`:
 1. Change the name of this file: use your Mac username (e.g. `com.micah.timeMachineScript.plist`)
@@ -18,3 +19,5 @@ A simple set of steps to create a simple script that is run every hour to automa
 4. Modify lines 16 and 18 to your liking or remove lines 15 through 18 altogether if you don't want logging
 5. Move the file to `/Users/username/Library/LaunchAgents` (where `username` is replaced with your Mac username)
 6. Run `launchctl load ~/Library/LaunchAgents/com.username.timeMachineScript.plist` (where `username` is replaced with your Mac username)
+
+Use it at your own risk.

--- a/com.username.timeMachineScript.plist
+++ b/com.username.timeMachineScript.plist
@@ -12,5 +12,9 @@
     <integer>3600</integer>
     <key>RunAtLoad</key>
     <true/>
+    <key>StandardOutPath</key>
+    <string>/tmp/timeMachineScript.log</string>
+    <key>StandardErrorPath</key>
+    <string>/tmp/timeMachineScript.log</string>
 </dict>
 </plist>

--- a/com.username.timeMachineScript.plist
+++ b/com.username.timeMachineScript.plist
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs$
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
 <plist version="1.0">
 <dict>
     <key>Label</key>

--- a/timeMachineScript.sh
+++ b/timeMachineScript.sh
@@ -1,5 +1,9 @@
 #!/bin/bash
 
+# Enable the "exit on error" option (this is needed for handling cases where backup disk is not plugged).
+set -e
+
+
 backupVolumeName=""
 backupVolumeUUID=""
 backupVolumeIdentifier=""
@@ -30,7 +34,7 @@ else
     if ! mount | grep -q "/Volumes/$backupVolumeName"; then
         echo "Backup disk '$backupVolumeName' is not mounted. Need to mount the encrypted disk."
         backupVolumePassword=security find-generic-password -a $backupVolumeUUID -w | xxd -p -r | rev | cut -c 1- | rev
-        diskutil apfs unlockVolume $backupVolumeIdentifier -user $backupVolumeUUID -passphrase $backupVolumePassword -verify
+        diskutil apfs unlockVolume $backupVolumeIdentifier -user $backupVolumeUUID -passphrase $backupVolumePassword # unlockVolume automatically mounts the disk
     fi
     echo "Starting backup now."
     tmutil startbackup --auto --block # wait for the backup to finish

--- a/timeMachineScript.sh
+++ b/timeMachineScript.sh
@@ -2,26 +2,33 @@
 
 backupVolumeName="BACKUP DISK NAME"
 
-# Check if the disk is mounted
-if ! mount | grep -q "/Volumes/$backupVolumeName"; then
-    echo "Backup disk '$backupVolumeName' is not mounted"
-    exit 0
-fi
+# # Check if the disk is mounted
+# if ! mount | grep -q "/Volumes/$backupVolumeName"; then
+#     echo "Backup disk '$backupVolumeName' is not mounted"
+#     exit 0
+# fi
+# echo "Backup disk '$backupVolumeName' is mounted"
 
 # Check if a backup is in progress
 if tmutil currentphase | grep -qv "BackupNotRunning"; then
     echo "Backup is in progress"
     exit 0
 fi
+echo "Backup is not in progress"
 
-# Check if a backup was completed today
-latestBackupDate=$(tmutil latestbackup | xargs -I {} basename {} | cut -d '-' -f 1-3)
-currentDate=$(date "+%Y-%m-%d")
+# Check if a backup was completed within the hour
+latestBackupFileName=$(tmutil latestbackup | xargs -I {} basename -s .backup {} | cut -d '-' -f 1-4)
+latestBackupTimestamp=$(date -j -f "%Y-%m-%d-%H%M%S" $latestBackupFileName "+%s") # -j is for parsing the input date
+currentTimestamp=$(date "+%s")
 
-if [ "$latestBackupDate" == "$currentDate" ]; then
-    echo "A backup was completed today"
+# Calculate the absolute difference in seconds
+secondsSinceLastBackup=$((currentTimestamp - latestBackupTimestamp))
+
+if [ "$secondsSinceLastBackup" -le 3600 ]; then
+    echo "A backup was completed less than 1 hour ago."
     diskutil eject "/Volumes/$backupVolumeName"
 else
-    echo "No backup completed today. Starting now."
+    echo "No backup completed since an hour. Starting now."
+    echo "Need to mount the encrypted disk"
     tmutil startbackup
 fi

--- a/timeMachineScript.sh
+++ b/timeMachineScript.sh
@@ -1,29 +1,21 @@
 #!/bin/bash
 
-# Enable the "exit on error" option (this is needed for handling cases where backup disk is not plugged).
+# Enable the "exit on error" option (this is needed for handling cases where backup disk cannot be mounted).
 set -e
 
+backupVolumeUUID="###################."
 
-backupVolumeName=""
-backupVolumeUUID=""
-backupVolumeIdentifier=""
+backupVolumeIdentifier=diskutil info $backupVolumeUUID | awk 'BEGIN{FS=":";}/Device Identifier:/{printf $NF}END{printf "\n"};' | xargs
+backupVolumeName=diskutil info $backupVolumeUUID | awk 'BEGIN{FS=":";}/Volume Name:/{print $NF}END{printf "\n"};' | xargs
 
-
-# Check if a backup is in progress
-if tmutil currentphase | grep -qv "BackupNotRunning"; then
-    echo "Backup is in progress, will try again later."
-    exit 0
-fi
-
-# Check if a backup was completed within the hour
+# Get the latest backup timestamp and calculate the difference in seconds
 latestBackupFileName=$(tmutil latestbackup | xargs -I {} basename -s .backup {} | cut -d '-' -f 1-4)
 latestBackupTimestamp=$(date -j -f "%Y-%m-%d-%H%M%S" $latestBackupFileName "+%s") # -j is for parsing the input date
 currentTimestamp=$(date "+%s")
-
-# Calculate the absolute difference in seconds
 secondsSinceLastBackup=$((currentTimestamp - latestBackupTimestamp))
 
-if [ "$secondsSinceLastBackup" -le 3600 ]; then
+# Backup takes around 5 minutes to complete, so check if the last backup was completed within the last 50 minutes
+if [ "$secondsSinceLastBackup" -le 3000 ]; then
     echo "A backup was completed less than 1 hour ago."
     if ! mount | grep -q "/Volumes/$backupVolumeName"; then
         echo "Backup disk '$backupVolumeName' is not mounted. Nothing to see here, move along."
@@ -31,15 +23,32 @@ if [ "$secondsSinceLastBackup" -le 3600 ]; then
     fi
 else
     echo "No backup completed since an hour."
-    if ! mount | grep -q "/Volumes/$backupVolumeName"; then
-        echo "Backup disk '$backupVolumeName' is not mounted. Need to mount the encrypted disk."
-        backupVolumePassword=security find-generic-password -a $backupVolumeUUID -w | xxd -p -r | rev | cut -c 1- | rev
-        diskutil apfs unlockVolume $backupVolumeIdentifier -user $backupVolumeUUID -passphrase $backupVolumePassword # unlockVolume automatically mounts the disk
+    if [ "$(tmutil currentphase)" = "BackupNotRunning" ]; then
+        echo "No backup is in progress. Starting backup now."
+        # Check if backup disk is mounted
+        if ! mount | grep -q "/Volumes/$backupVolumeName"; then
+            echo "Backup disk '$backupVolumeName' is not mounted. Need to mount the encrypted disk."
+            backupVolumePassword=security find-generic-password -a $backupVolumeUUID -w | xxd -p -r | rev | cut -c 1- | rev
+            diskutil apfs unlockVolume $backupVolumeIdentifier -user $backupVolumeUUID -passphrase $backupVolumePassword # unlockVolume automatically mounts the disk
+            # This command will fail if the backup disk is not available and script will exit with set -e
+        fi
+        tmutil startbackup --auto --block # wait for the backup to finish
+    else
+        echo "Backup is in progress, need to wait before ejecting the disk."
+        while [ "$(tmutil currentphase)" != "BackupNotRunning" ]; do
+            percentCompleted=$(tmutil status | grep _raw_Percent | xargs | sed -e 's/[^0-9.]*//g')
+            timeRemaining=$(tmutil status | grep TimeRemaining | xargs | sed -e 's/[^0-9.]*//g')
+
+            percentCompleted=${percentCompleted:-0}
+            timeRemaining=${timeRemaining:-10}
+
+            sleepDuration=$(awk "BEGIN {print (1-$percentCompleted)*$timeRemaining}")
+            echo "Backup is still in progress, will check again in $sleepDuration seconds."
+            sleep $sleepDuration
+        done
     fi
-    echo "Starting backup now."
-    tmutil startbackup --auto --block # wait for the backup to finish
-    echo "Backup finished."
+    echo "Backup is finished."
 fi
 
-echo "Ejecting backup disk."
-diskutil eject "/Volumes/$backupVolumeName"
+echo "Ejecting the backup disk."
+diskutil eject "$backupVolumeIdentifier"

--- a/timeMachineScript.sh
+++ b/timeMachineScript.sh
@@ -5,8 +5,8 @@ set -e
 
 backupVolumeUUID="###################."
 
-backupVolumeIdentifier=diskutil info $backupVolumeUUID | awk 'BEGIN{FS=":";}/Device Identifier:/{printf $NF}END{printf "\n"};' | xargs
-backupVolumeName=diskutil info $backupVolumeUUID | awk 'BEGIN{FS=":";}/Volume Name:/{print $NF}END{printf "\n"};' | xargs
+backupVolumeIdentifier=$(diskutil info $backupVolumeUUID | awk 'BEGIN{FS=":";}/Device Identifier:/{printf $NF}END{printf "\n"};' | xargs)
+backupVolumeName=$(diskutil info $backupVolumeUUID | awk 'BEGIN{FS=":";}/Volume Name:/{print $NF}END{printf "\n"};' | xargs)
 
 # Get the latest backup timestamp and calculate the difference in seconds
 latestBackupFileName=$(tmutil latestbackup | xargs -I {} basename -s .backup {} | cut -d '-' -f 1-4)

--- a/timeMachineScript.sh
+++ b/timeMachineScript.sh
@@ -3,52 +3,59 @@
 # Enable the "exit on error" option (this is needed for handling cases where backup disk cannot be mounted).
 set -e
 
-backupVolumeUUID="###################."
+echo "================================================================================"
+echo "timeMachineScript.sh is launched."
+
+backupVolumeUUID="****"
 
 backupVolumeIdentifier=$(diskutil info $backupVolumeUUID | awk 'BEGIN{FS=":";}/Device Identifier:/{printf $NF}END{printf "\n"};' | xargs)
 backupVolumeName=$(diskutil info $backupVolumeUUID | awk 'BEGIN{FS=":";}/Volume Name:/{print $NF}END{printf "\n"};' | xargs)
 
+# Check if backup disk is mounted, mount it if not
+if ! mount | grep -q "/Volumes/$backupVolumeName"; then
+    echo "Backup disk '$backupVolumeName' is not mounted. Need to mount the encrypted disk."
+    backupVolumePassword=$(security find-generic-password -a $backupVolumeUUID -w | xxd -p -r | rev | cut -c 1- | rev)
+    diskutil apfs unlockVolume $backupVolumeIdentifier -user $backupVolumeUUID -passphrase $backupVolumePassword # unlockVolume automatically mounts the disk
+    # This command will fail if the backup disk is not available and script will exit with set -e
+fi
+
 # Get the latest backup timestamp and calculate the difference in seconds
-latestBackupFileName=$(tmutil latestbackup | xargs -I {} basename -s .backup {} | cut -d '-' -f 1-4)
-latestBackupTimestamp=$(date -j -f "%Y-%m-%d-%H%M%S" $latestBackupFileName "+%s") # -j is for parsing the input date
+latestBackupFileDate=$(tmutil latestbackup | xargs -I {} basename -s .backup {} | cut -d '-' -f 1-4)
+echo "Latest backup file date: $latestBackupFileDate"
+latestBackupTimestamp=$(date -j -f "%Y-%m-%d-%H%M%S" $latestBackupFileDate "+%s") # -j is for parsing the input date
+echo "Latest backup timestamp: $latestBackupTimestamp"
 currentTimestamp=$(date "+%s")
+echo "Current time: $(date "+%Y-%m-%d %H:%M:%S")"
+echo "Current timestamp: $currentTimestamp"
 secondsSinceLastBackup=$((currentTimestamp - latestBackupTimestamp))
+echo "Difference in seconds: $secondsSinceLastBackup"
 
 # Backup takes around 5 minutes to complete, so check if the last backup was completed within the last 50 minutes
 if [ "$secondsSinceLastBackup" -le 3000 ]; then
-    echo "A backup was completed less than 1 hour ago."
-    if ! mount | grep -q "/Volumes/$backupVolumeName"; then
-        echo "Backup disk '$backupVolumeName' is not mounted. Nothing to see here, move along."
-        exit 0
-    fi
+    echo "A backup was completed less than 1 hour ago, will eject the disk."
 else
-    echo "No backup completed since an hour."
+    echo "No backup has been completed since an hour."
     if [ "$(tmutil currentphase)" = "BackupNotRunning" ]; then
         echo "No backup is in progress. Starting backup now."
-        # Check if backup disk is mounted
-        if ! mount | grep -q "/Volumes/$backupVolumeName"; then
-            echo "Backup disk '$backupVolumeName' is not mounted. Need to mount the encrypted disk."
-            backupVolumePassword=security find-generic-password -a $backupVolumeUUID -w | xxd -p -r | rev | cut -c 1- | rev
-            diskutil apfs unlockVolume $backupVolumeIdentifier -user $backupVolumeUUID -passphrase $backupVolumePassword # unlockVolume automatically mounts the disk
-            # This command will fail if the backup disk is not available and script will exit with set -e
-        fi
-        tmutil startbackup --auto --block # wait for the backup to finish
-    else
-        echo "Backup is in progress, need to wait before ejecting the disk."
-        while [ "$(tmutil currentphase)" != "BackupNotRunning" ]; do
-            percentCompleted=$(tmutil status | grep _raw_Percent | xargs | sed -e 's/[^0-9.]*//g')
-            timeRemaining=$(tmutil status | grep TimeRemaining | xargs | sed -e 's/[^0-9.]*//g')
-
-            percentCompleted=${percentCompleted:-0}
-            timeRemaining=${timeRemaining:-10}
-
-            sleepDuration=$(awk "BEGIN {print (1-$percentCompleted)*$timeRemaining}")
-            echo "Backup is still in progress, will check again in $sleepDuration seconds."
-            sleep $sleepDuration
-        done
+        tmutil startbackup --auto # wait for the backup to finish
     fi
-    echo "Backup is finished."
 fi
 
-echo "Ejecting the backup disk."
+while [ "$(tmutil currentphase)" != "BackupNotRunning" ]; do
+    percentCompleted=$(tmutil status | grep _raw_Percent | xargs | sed -e 's/[^0-9.]*//g')
+    timeRemaining=$(tmutil status | grep TimeRemaining | xargs | sed -e 's/[^0-9.]*//g')
+
+    percentCompleted=${percentCompleted:-0}
+    timeRemaining=${timeRemaining:-10}
+
+    # timeRemaining is not very accurate at the end of the backup
+    # multiply it with a factor to make it more accurate
+    sleepDuration=$(awk "BEGIN {print (1-($percentCompleted*$percentCompleted))*$timeRemaining}")
+
+    echo "Backup is in progress ($percentCompleted), will check again in $sleepDuration seconds."
+    sleep $sleepDuration
+done
+
 diskutil eject "$backupVolumeIdentifier"
+echo "Backup disk '$backupVolumeName' is ejected."
+echo "================================================================================"


### PR DESCRIPTION
Some unsolicited improvements, feel free to close if this is not what you need/want. 

I modified the script for my particular need to mount an encrypted backup disk and backup every hour. And eject the disk right after backup is finished while respecting ongoing backup processes. 

The script fetches the password from the master keychain (assuming it exists there, normally it should exist with the UUID of the backup volume). However I am afraid this means the script wouldn't work for unencrypted disk nor if the password is not registered in the master keychain. These cases can be handled by some flags but since the script already covers my use case, I didn't want to spend more time on it.  

Also, thanks a lot for this tool! I keep forgetting to eject the disk before unplugging my laptop and now the disk is mounted only for ~5 minutes every hour.